### PR TITLE
Get rid of ActiveSupport dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,18 +32,12 @@ PATH
   remote: .
   specs:
     karafka-sidekiq-backend (1.3.0)
-      activesupport (>= 4.0)
       karafka (~> 1.3)
       sidekiq (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
     delivery_boy (0.2.7)
@@ -100,12 +94,9 @@ GEM
       dry-schema (~> 1.0, >= 1.1.0)
     envlogic (1.1.0)
       dry-inflector (~> 0.1)
-    i18n (1.6.0)
-      concurrent-ruby (~> 1.0)
     irb (1.0.0)
     json (2.2.0)
     king_konf (0.3.7)
-    minitest (5.11.3)
     multi_json (1.13.1)
     rack (2.0.7)
     rack-protection (2.0.5)
@@ -138,10 +129,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     thor (0.20.3)
-    thread_safe (0.3.6)
     timecop (0.9.1)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
     zeitwerk (2.1.8)
 
 PLATFORMS

--- a/karafka-sidekiq-backend.gemspec
+++ b/karafka-sidekiq-backend.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
   spec.description = 'Karafka Sidekiq backend for background messages processing'
   spec.license     = 'MIT'
 
-  spec.add_dependency 'activesupport', '>= 4.0'
   spec.add_dependency 'karafka', '~> 1.3'
   spec.add_dependency 'sidekiq', '>= 4.2'
   spec.required_ruby_version = '>= 2.4.0'

--- a/lib/karafka/base_worker.rb
+++ b/lib/karafka/base_worker.rb
@@ -5,6 +5,22 @@ module Karafka
   class BaseWorker
     include Sidekiq::Worker
 
+    class << self
+      # Returns the base worker class for application.
+      #
+      # @return [Class] first worker that inherited from Karafka::BaseWorker. Karafka
+      #   assimes that it is the base worker for an application.
+      # @raise [Karafka::Errors::BaseWorkerDescentantMissing] raised when application
+      #   base worker was not defined.
+      def base_worker
+        @base_worker || raise(Errors::BaseWorkerDescentantMissing)
+      end
+
+      def inherited(subclass)
+        @base_worker ||= subclass
+      end
+    end
+
     # Executes the logic that lies in #perform Karafka consumer method
     # @param topic_id [String] Unique topic id that we will use to find a proper topic
     # @param params_batch [Array<Hash>] Array with messages batch

--- a/lib/karafka/workers/builder.rb
+++ b/lib/karafka/workers/builder.rb
@@ -24,19 +24,11 @@ module Karafka
       def build
         return matcher.match if matcher.match
 
-        klass = Class.new(base)
+        klass = Class.new(Karafka::BaseWorker.base_worker)
         matcher.scope.const_set(matcher.name, klass)
       end
 
       private
-
-      # @return [Class] descendant of Karafka::BaseWorker from which all other workers
-      #   should inherit
-      # @raise [Karafka::Errors::BaseWorkerDescentantMissing] raised when Karafka cannot detect
-      #   direct Karafka::BaseWorker descendant from which it could build workers
-      def base
-        Karafka::BaseWorker.subclasses.first || raise(Errors::BaseWorkerDescentantMissing)
-      end
 
       # @return [Karafka::Helpers::ClassMatcher] matcher instance for matching between consumer
       #   and appropriate worker

--- a/lib/karafka_sidekiq_backend.rb
+++ b/lib/karafka_sidekiq_backend.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-# @note Active Support is already included since Karafka is using it directly so no need
-#   to require it again in the gemspec, etc
 %w[
-  active_support/core_ext/class/subclasses
   karafka
   sidekiq
 ].each(&method(:require))


### PR DESCRIPTION
Hey,

I thought it would be nice to simplify the gem and remove unnecessary dependency on active support. There was only 1 usage of `Class#subclasses` method that could be easily replaced with `inherited` hook giving the same end result - the first class that inherited from `Karafka::BaseWorker`.