### PR TITLE
Stop loading project lib directory

### DIFF
--- a/lib/karafka_sidekiq_backend.rb
+++ b/lib/karafka_sidekiq_backend.rb
@@ -13,7 +13,6 @@ Zeitwerk::Loader
   .tap { |loader| loader.ignore("#{__dir__}/karafka-sidekiq-backend.rb") }
   .tap(&:setup)
   .tap(&:eager_load)
-  .tap { |loader| loader.preload('lib/') }
 
 Karafka::Params::Builders::Params.extend(Karafka::Extensions::ParamsBuilder)
 Karafka::Params::Builders::ParamsBatch.extend(Karafka::Extensions::ParamsBatchBuilder)


### PR DESCRIPTION
Zeitwerk was loading project lib directory if sidekiq-backend gem was required. `Zeitwerk.for_gem` already adds GEM's lib directory, no need to add it manually.