### PR TITLE
Fix interchanger documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ App.routes.draw do
       backend :sidekiq
       consumer Videos::DetailsConsumer
       worker Workers::DetailsWorker
-      interchanger Interchangers::MyCustomInterchanger
+      interchanger Interchangers::MyCustomInterchanger.new
     end
   end
 end
@@ -64,7 +64,7 @@ There are two options you can set inside of the ```topic``` block:
 | Option       | Value type | Description                                                                                                       |
 |--------------|------------|-------------------------------------------------------------------------------------------------------------------|
 | worker       | Class      | Name of a worker class that we want to use to schedule perform code                                               |
-| interchanger | Class      | Name of an interchanger class that we want to use to pass the incoming data to Sidekiq                            |
+| interchanger | Instance   | Instance of an interchanger class that we want to use to pass the incoming data to Sidekiq                        |
 
 
 ### Workers
@@ -102,7 +102,7 @@ App.routes.draw do
   consumer_group :videos_consumer do
     topic :binary_video_details do
       consumer Videos::DetailsConsumer
-      interchanger Interchangers::MyCustomInterchanger
+      interchanger Interchangers::MyCustomInterchanger.new
     end
   end
 end

--- a/lib/karafka/extensions/sidekiq_topic_attributes.rb
+++ b/lib/karafka/extensions/sidekiq_topic_attributes.rb
@@ -11,8 +11,8 @@ module Karafka
         @worker ||= backend == :sidekiq ? Karafka::Workers::Builder.new(consumer).build : nil
       end
 
-      # @return [Class] Interchanger class (not an instance) that we want to use to interchange
-      #   params between Karafka server and Karafka background job
+      # @return [#encode, #decode] Interchanger instance (not a class) that we want to use to
+      #   interchange params between Karafka server and Karafka background job
       def interchanger
         @interchanger ||= Karafka::Interchanger.new
       end

--- a/spec/lib/karafka/backends/sidekiq_spec.rb
+++ b/spec/lib/karafka/backends/sidekiq_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Karafka::Backends::Sidekiq do
   subject(:consumer) { consumer_class.new(topic) }
 
   let(:consumer_class) { Class.new(Karafka::BaseConsumer) }
-  let(:interchanger) { Karafka::Interchanger }
+  let(:interchanger) { instance_double(Karafka::Interchanger) }
   let(:params_batch) { [{ value: rand.to_s }] }
   let(:interchanged_data) { params_batch }
   let(:topic) do


### PR DESCRIPTION
As of https://github.com/karafka/sidekiq-backend/commit/82179051fa79a91b50bcaf2b19d1ad021e285e28, the `interchanger` option accepts an instance, not a class, as you might mistakenly guess from the docs and examples provided. Otherwise, Karafka raises:

```
undefined method 'encode' for Interchangers::MyCustomInterchanger:Class
```

Update README and specs accordingly to not waste time for debugging.

Relates to https://github.com/karafka/sidekiq-backend/pull/11.
Follow-up for https://github.com/karafka/sidekiq-backend/pull/76.