### PR TITLE
drop support for ruby 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
           - '3.1'
           - '3.0'
           - '2.7'
-          - '2.6'
-          - 'jruby-9.3.1.0'
         include:
           - ruby: '3.1'
             coverage: 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Ruby 3.1 support
+- Drop support for ruby 2.6
 
 ## 1.4.3 (2021-12-05)
 - Source code metadata url added to the gemspec

--- a/karafka-sidekiq-backend.gemspec
+++ b/karafka-sidekiq-backend.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'karafka', '~> 1.4.0'
   spec.add_dependency 'sidekiq', '>= 4.2'
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.7'
 
   if $PROGRAM_NAME.end_with?('gem')
     spec.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')


### PR DESCRIPTION
We are officially dropping support for ruby 2.6 because maintenance ends beginning of April 2022. More information in this post https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/. We also can't support JRuby because it is currently based on ruby 2.6.