### PR TITLE
Fix Hash#except usage

### DIFF
--- a/lib/karafka/backends/sidekiq.rb
+++ b/lib/karafka/backends/sidekiq.rb
@@ -20,7 +20,9 @@ module Karafka
                                   # We remove deserializer as it's not safe to convert it to json
                                   # and we can rebuild it anyhow based on the routing data in the
                                   # worker
-                                  batch_metadata.to_h.transform_keys(&:to_s).except('deserializer')
+                                  batch_metadata.to_h
+                                                .transform_keys(&:to_s)
+                                                .tap { |h| h.delete('deserializer') }
                                 end
 
           topic.worker.perform_async(

--- a/spec/lib/karafka/backends/sidekiq_spec.rb
+++ b/spec/lib/karafka/backends/sidekiq_spec.rb
@@ -32,7 +32,17 @@ RSpec.describe Karafka::Backends::Sidekiq do
   end
 
   context 'when batch_metadata is available for the consumer instance' do
-    pending
+    before do
+      consumer.define_singleton_method(:batch_metadata) do
+        { a: 1, deserializer: Object.new }
+      end
+    end
+
+    it 'expect to schedule with sidekiq using interchanged data' do
+      expect(topic.worker).to receive(:perform_async)
+        .with(topic.id, interchanged_data, { 'a' => 1 })
+      consumer.call
+    end
   end
 
   context 'when batch_metadata is not available for the consumer instance' do


### PR DESCRIPTION
There is no `Hash#except` in Ruby, use tap/delete as alternative.