### PR TITLE
Serialize timestamps as strings

### DIFF
--- a/lib/karafka/interchanger.rb
+++ b/lib/karafka/interchanger.rb
@@ -21,8 +21,8 @@ module Karafka
         metadata_hash.delete('deserializer')
 
         # Cast times to strings, we will de-serialize it back in Sidekiq
-        metadata_hash['receive_time'] = metadata_hash['receive_time'].to_f
-        metadata_hash['create_time'] = metadata_hash['create_time'].to_f
+        metadata_hash['receive_time'] = metadata_hash['receive_time'].to_f.to_s
+        metadata_hash['create_time'] = metadata_hash['create_time'].to_f.to_s
 
         {
           'raw_payload' => param.raw_payload,
@@ -37,8 +37,8 @@ module Karafka
       params_batch.map do |param|
         metadata = param['metadata']
         # Covert serialized dates back to what they were
-        metadata['receive_time'] = Time.at(metadata['receive_time']).to_time
-        metadata['create_time'] = Time.at(metadata['create_time']).to_time
+        metadata['receive_time'] = Time.at(metadata['receive_time'].to_f).to_time
+        metadata['create_time'] = Time.at(metadata['create_time'].to_f).to_time
 
         param['metadata'] = metadata
 

--- a/spec/lib/karafka/interchanger_spec.rb
+++ b/spec/lib/karafka/interchanger_spec.rb
@@ -3,14 +3,15 @@
 RSpec.describe Karafka::Interchanger do
   subject(:interchanger) { described_class.new }
 
+  let(:time) { Time.at(111_111_111_1.9999999).to_time }
   let(:array_params_batch) do
     [
       Karafka::Params::Params.new(
         1,
         Karafka::Params::Metadata.new(
           deserializer: 'Class',
-          create_time: Time.now,
-          receive_time: Time.now
+          create_time: time,
+          receive_time: time
         )
       )
     ]
@@ -30,8 +31,8 @@ RSpec.describe Karafka::Interchanger do
              .transform_keys(&:to_s)
              .tap { |hash| hash.delete('deserializer') }
 
-      meta['create_time'] = meta['create_time'].to_f
-      meta['receive_time'] = meta['receive_time'].to_f
+      meta['create_time'] = meta['create_time'].to_f.to_s
+      meta['receive_time'] = meta['receive_time'].to_f.to_s
 
       meta
     end
@@ -43,11 +44,12 @@ RSpec.describe Karafka::Interchanger do
   end
 
   describe '#decode' do
-    subject(:decoded) { described_class.new.decode(encoded) }
+    subject(:decoded) { described_class.new.decode(encoded_and_processed) }
 
+    let(:encoded_and_processed) { JSON.load(JSON.dump(encoded)) } # rubocop:disable JSONLoad
     let(:encoded) { described_class.new.encode(params_batch) }
 
-    it { expect(decoded).to eq(encoded) }
+    it { expect(decoded).to eq(encoded_and_processed) }
     it { expect(decoded[0].keys).not_to include('deserializer') }
   end
 end


### PR DESCRIPTION
Karafka sidekiq-backend serilazes timestamps in metadata as floats. Sometimes floats are too long and it causes Sidekiq to warn that "Job arguments to KarafkaBaseWorker do not serialize to JSON safely", which is because such floats cannot be safely serialized to JSON.
According to https://github.com/mperham/sidekiq/wiki/Best-Practices `JSON.dump` and `JSON.load` are used for serialization.deserialization, and you can see that some timestamps cannot be serialized without rounding:
```ruby
JSON.dump({'time' => 1111111111.9999999}) # => "{\"time\":1111111112.0}"
```
However converting timestamps to strings before serialization and back to floats after works it around.