### PR TITLE
Update Zeitwerk::Loader.for_gem

### DIFF
--- a/lib/karafka_sidekiq_backend.rb
+++ b/lib/karafka_sidekiq_backend.rb
@@ -8,7 +8,7 @@
 require_relative 'karafka/errors'
 
 Zeitwerk::Loader
-  .for_gem
+  .for_gem(warn_on_extra_files: false)
   .tap { |loader| loader.ignore("#{__dir__}/karafka_sidekiq_backend.rb") }
   .tap { |loader| loader.ignore("#{__dir__}/karafka-sidekiq-backend.rb") }
   .tap(&:setup)


### PR DESCRIPTION
Trying to get rid of the following warning introduced by adding `karafka/sidekiq-backend` as dependency to a Rails project:
```
WARNING: Zeitwerk defines the constant Karafka after the directory

    /home/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/karafka-sidekiq-backend-1.4.7/lib/karafka

To prevent that, please configure the loader to ignore it:

    loader.ignore("#{__dir__}/karafka")

Otherwise, there is a flag to silence this warning:

    Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
WARNING: Zeitwerk defines the constant Karafka after the file

    /home/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/karafka-sidekiq-backend-1.4.7/lib/karafka.rb

To prevent that, please configure the loader to ignore it:

    loader.ignore("#{__dir__}/karafka.rb")

Otherwise, there is a flag to silence this warning:

    Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
```

I followed this section in `fxn/zeitwerk`, which indeed fixed the issue, but I am not sure if this is the way to go here:
- https://github.com/fxn/zeitwerk#reopening-third-party-namespaces